### PR TITLE
Rename HTMLDocument class to HTMLDocumentProtector

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ request will fail to pass Step 2 when the page gets submitted!
     $htmlIn = "<html>...</html>"
     
     // now do the processing
-    $page = new HTMLDocument($html, $tokenStore);
+    $page = new HTMLDocumentProtector($html, $tokenStore);
     $page->protectAndInject();
     
     // and you can get it back out however you wish.  

--- a/composer.json
+++ b/composer.json
@@ -4,9 +4,9 @@
   "type": "library",
 
   "require": {
-    "php": ">=7.0.0",
+    "php": "^7",
     "phpgt/dom": "*",
-    "ircmaxell/random-lib": "*"
+    "ircmaxell/random-lib": "^1.1"
   },
   "require-dev": {
     "phpunit/phpunit": "^5.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "4e92992b07d7c62b1998f0059a4ba0fe",
-    "content-hash": "c05010d9e878bde0150e26595b4458db",
+    "hash": "c90980082aa8714e36ac5e2563fc075a",
+    "content-hash": "45afc059a8281a7d3b76e9cf9ae8a98b",
     "packages": [
         {
             "name": "ircmaxell/random-lib",
@@ -1297,7 +1297,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.0.0"
+        "php": "^7"
     },
     "platform-dev": {
         "ext-xdebug": "*"

--- a/src/HTMLDocumentProtector.php
+++ b/src/HTMLDocumentProtector.php
@@ -2,7 +2,7 @@
 namespace phpgt\csrf;
 
 
-class HTMLDocument {
+class HTMLDocumentProtector {
 	public static $TOKEN_NAME = "csrf-token";
 	private       $doc;
 	private       $tokenStore;

--- a/src/TokenStore.php
+++ b/src/TokenStore.php
@@ -25,12 +25,12 @@ abstract class TokenStore {
 	public function processAndVerify() {
 		// expect the token to be present on ALL post requests
 		if(!empty($_POST)) {
-			if(!isset($_POST[ HTMLDocument::$TOKEN_NAME ])) {
+			if(!isset($_POST[ HTMLDocumentProtector::$TOKEN_NAME ])) {
 				throw new CSRFTokenMissingException();
 			}
 
-			$this->verifyToken($_POST[ HTMLDocument::$TOKEN_NAME ]);
-			$this->consumeToken($_POST[ HTMLDocument::$TOKEN_NAME ]);
+			$this->verifyToken($_POST[ HTMLDocumentProtector::$TOKEN_NAME ]);
+			$this->consumeToken($_POST[ HTMLDocumentProtector::$TOKEN_NAME ]);
 		}
 	}
 

--- a/test/HTMLDocumentProtectorTest.test.php
+++ b/test/HTMLDocumentProtectorTest.test.php
@@ -1,7 +1,7 @@
 <?php
 namespace phpgt\csrf;
 
-class HTMLDocumentTest extends \PHPUnit_Framework_TestCase {
+class HTMLDocumentProtectorTest extends \PHPUnit_Framework_TestCase {
 	const NO_FORMS
 		= <<<HTML
 <!doctype html>
@@ -60,7 +60,7 @@ HTML;
 HTML;
 
 	public function testConstructFromString() {
-		$sut = new HTMLDocument(self::NO_FORMS, new ArrayTokenStore());
+		$sut = new HTMLDocumentProtector(self::NO_FORMS, new ArrayTokenStore());
 		$doc = $sut->getHTMLDocument();
 		$this->assertInstanceOf("\\phpgt\\dom\\HTMLDocument", $doc);
 		$this->assertEquals(
@@ -69,7 +69,7 @@ HTML;
 
 	public function testConstructFromDomDocument() {
 		$domDoc = new \phpgt\dom\HTMLDocument(self::ONE_FORM);
-		$sut = new HTMLDocument($domDoc, new ArrayTokenStore());
+		$sut = new HTMLDocumentProtector($domDoc, new ArrayTokenStore());
 		$doc = $sut->getHTMLDocument();
 		$this->assertSame($domDoc, $doc);
 		$this->assertEquals(
@@ -77,44 +77,44 @@ HTML;
 	}
 
 	public function testZeroForms() {
-		$sut = new HTMLDocument(self::NO_FORMS, new ArrayTokenStore());
+		$sut = new HTMLDocumentProtector(self::NO_FORMS, new ArrayTokenStore());
 		$sut->protectAndInject();
 
 		// check that the token hasn't been injected anywhere
 		$this->assertFalse(
 			strpos(
 				$sut->getHTMLDocument()->saveHTML(),
-				HTMLDocument::$TOKEN_NAME));
+				HTMLDocumentProtector::$TOKEN_NAME));
 		// and that a form hasn't been created or something similar
 		$this->assertNull($sut->getHTMLDocument()->querySelector("form"));
 	}
 
 	public function testSingleForm() {
-		$sut = new HTMLDocument(self::ONE_FORM, new ArrayTokenStore());
+		$sut = new HTMLDocumentProtector(self::ONE_FORM, new ArrayTokenStore());
 		$sut->protectAndInject();
 
 		// check that the token has been injected
 		$doc = $sut->getHTMLDocument();
 		$this->assertTrue(
-			strpos($doc->saveHTML(), HTMLDocument::$TOKEN_NAME) >= 0);
+			strpos($doc->saveHTML(), HTMLDocumentProtector::$TOKEN_NAME) >= 0);
 		$this->assertNotNull(
 			$doc->querySelector(
-				"input[name='" . HTMLDocument::$TOKEN_NAME . "']"));
+				"input[name='" . HTMLDocumentProtector::$TOKEN_NAME . "']"));
 		$this->assertNotEmpty(
 			$doc->querySelector(
-				"input[name='" . HTMLDocument::$TOKEN_NAME . "']")
+				"input[name='" . HTMLDocumentProtector::$TOKEN_NAME . "']")
 			    ->getAttribute("value"));
 	}
 
 	public function testMultipleForms() {
-		$sut = new HTMLDocument(self::THREE_FORMS, new ArrayTokenStore());
+		$sut = new HTMLDocumentProtector(self::THREE_FORMS, new ArrayTokenStore());
 		$sut->protectAndInject();
 
 		// check that the token has been injected in all forms
 		$doc = $sut->getHTMLDocument();
 		$this->assertEquals(
 			3, $doc->querySelectorAll(
-			"input[name='" . HTMLDocument::$TOKEN_NAME . "']")->length);
+			"input[name='" . HTMLDocumentProtector::$TOKEN_NAME . "']")->length);
 	}
 
 	// we don't need separate tokens for each form - that would be both wasteful,
@@ -124,13 +124,13 @@ HTML;
 	// across all of the forms
 	public function testSingleCodeSharedAcrossForms() {
 
-		$sut = new HTMLDocument(self::THREE_FORMS, new ArrayTokenStore());
+		$sut = new HTMLDocumentProtector(self::THREE_FORMS, new ArrayTokenStore());
 		$sut->protectAndInject();
 
 		$doc = $sut->getHTMLDocument();
 		$token = null;
 		foreach($doc->querySelectorAll(
-			"input[name='" . HTMLDocument::$TOKEN_NAME . "']") as $input) {
+			"input[name='" . HTMLDocumentProtector::$TOKEN_NAME . "']") as $input) {
 			if($token === null) {
 				$token = $input->getAttribute("value");
 			} else {

--- a/test/TokenStoreTest.test.php
+++ b/test/TokenStoreTest.test.php
@@ -39,7 +39,7 @@ HTML;
 	// POST request received with token but invalid
 	public function testInvalidToken() {
 		$_POST["doink"] = "binky";
-		$_POST[ HTMLDocument::$TOKEN_NAME ] = "12321";
+		$_POST[ HTMLDocumentProtector::$TOKEN_NAME ] = "12321";
 		$sut = new ArrayTokenStore();
 		$this->expectException(
 			"\\phpgt\\csrf\\exception\\CSRFTokenInvalidException");
@@ -55,7 +55,7 @@ HTML;
 
 		$_POST["doink"] = "binky";
 		// add the token as if it were from a previous page
-		$_POST[ HTMLDocument::$TOKEN_NAME ] = $token;
+		$_POST[ HTMLDocumentProtector::$TOKEN_NAME ] = $token;
 
 		$this->expectException(
 			"\\phpgt\\csrf\\exception\\CSRFTokenSpentException");
@@ -70,7 +70,7 @@ HTML;
 
 		$_POST["doink"] = "binky";
 		// add the token as if it were from a previous page
-		$_POST[ HTMLDocument::$TOKEN_NAME ] = $token;
+		$_POST[ HTMLDocumentProtector::$TOKEN_NAME ] = $token;
 
 		$tokenStore->processAndVerify();
 	}


### PR DESCRIPTION
Also pin composer dependencies to versions that should not be backwards breaking.