### PR TITLE
Use the phpgt/dom ->forms property

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,10 @@
     "phpunit/php-code-coverage": "*",
     "ext-xdebug": "*"
   },
+  "minimum-stability": "stable",
+  "scripts": {
+    "test": "./vendor/bin/phpunit -c ./phpunit.xml"
+  },
 
   "license": "MIT",
 

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "c90980082aa8714e36ac5e2563fc075a",
-    "content-hash": "45afc059a8281a7d3b76e9cf9ae8a98b",
+    "hash": "2836c7d51d016c7c642d28f2a56514f6",
+    "content-hash": "69d51680df49cfb48d9a7886d080a1b1",
     "packages": [
         {
             "name": "ircmaxell/random-lib",
@@ -104,16 +104,16 @@
         },
         {
             "name": "phpgt/dom",
-            "version": "v0.0.2",
+            "version": "v0.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpgt/dom.git",
-                "reference": "01e9c9e7a7a1fd4c508e177459a8c8d419961e0f"
+                "reference": "a9b8ef5955717010b74939b114cbd5d1168e52b5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpgt/dom/zipball/01e9c9e7a7a1fd4c508e177459a8c8d419961e0f",
-                "reference": "01e9c9e7a7a1fd4c508e177459a8c8d419961e0f",
+                "url": "https://api.github.com/repos/phpgt/dom/zipball/a9b8ef5955717010b74939b114cbd5d1168e52b5",
+                "reference": "a9b8ef5955717010b74939b114cbd5d1168e52b5",
                 "shasum": ""
             },
             "require": {
@@ -140,7 +140,7 @@
                 }
             ],
             "description": "Enhancement to the PHP DOMDocument functionality.",
-            "time": "2016-02-03 22:09:59"
+            "time": "2016-02-23 23:04:00"
         },
         {
             "name": "symfony/css-selector",
@@ -938,16 +938,16 @@
         },
         {
             "name": "sebastian/environment",
-            "version": "1.3.3",
+            "version": "1.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "6e7133793a8e5a5714a551a8324337374be209df"
+                "reference": "dc7a29032cf72b54f36dac15a1ca5b3a1b6029bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/6e7133793a8e5a5714a551a8324337374be209df",
-                "reference": "6e7133793a8e5a5714a551a8324337374be209df",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/dc7a29032cf72b54f36dac15a1ca5b3a1b6029bf",
+                "reference": "dc7a29032cf72b54f36dac15a1ca5b3a1b6029bf",
                 "shasum": ""
             },
             "require": {
@@ -984,7 +984,7 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2015-12-02 08:37:27"
+            "time": "2016-02-26 18:40:46"
         },
         {
             "name": "sebastian/exporter",

--- a/src/HTMLDocumentProtector.php
+++ b/src/HTMLDocumentProtector.php
@@ -1,6 +1,7 @@
 <?php
 namespace phpgt\csrf;
 
+use phpgt\dom\HTMLDocument;
 
 class HTMLDocumentProtector {
 	public static $TOKEN_NAME = "csrf-token";
@@ -10,15 +11,15 @@ class HTMLDocumentProtector {
 	public function __construct($html, TokenStore $tokenStore) {
 		$this->tokenStore = $tokenStore;
 
-		if($html instanceof \phpgt\dom\HTMLDocument) {
+		if($html instanceof HTMLDocument) {
 			$this->doc = $html;
 		} else {
-			$this->doc = new \phpgt\dom\HTMLDocument($html);
+			$this->doc = new HTMLDocument($html);
 		}
 	}
 
 	public function protectAndInject() {
-		$forms = $this->doc->querySelectorAll("form");
+		$forms = $this->doc->forms;
 		if($forms->length > 0) {
 			$token = $this->tokenStore->generateNewToken();
 			$this->tokenStore->saveToken($token);

--- a/test/HTMLDocumentProtectorTest.test.php
+++ b/test/HTMLDocumentProtectorTest.test.php
@@ -14,6 +14,7 @@ class HTMLDocumentProtectorTest extends \PHPUnit_Framework_TestCase {
 	<h1>This HTML is for the unit test.</h1>
 	<p>There are a few elements in this document.</p>
 </body>
+</html>
 HTML;
 
 	const ONE_FORM
@@ -32,6 +33,7 @@ HTML;
         <button type="submit"></button>
     </form>
 </body>
+</html>
 HTML;
 
 	const THREE_FORMS
@@ -57,6 +59,7 @@ HTML;
     <form method="POST">
     </form>
 </body>
+</html>
 HTML;
 
 	public function testConstructFromString() {


### PR DESCRIPTION
Closes #2.

Requires the updated phpgt/dom composer dependency.

Also added a composer script to run tests, making it as easy as running
`composer test` to execute the tests.