### PR TITLE
Implement PSR2 coding standard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 composer.phar
 /vendor
 /test/_Report
+.php_cs.cache

--- a/.php_cs
+++ b/.php_cs
@@ -1,0 +1,13 @@
+<?php
+
+$finder = Symfony\CS\Finder\DefaultFinder::create()
+    ->in(__DIR__ . "/src")
+    ->in(__DIR__ . "/test")
+    ->exclude(__DIR__ . "/test/_Report")
+;
+
+return Symfony\CS\Config\Config::create()
+    ->level(Symfony\CS\FixerInterface::PSR2_LEVEL)
+    ->setUsingCache(true)
+    ->finder($finder)
+;

--- a/composer.json
+++ b/composer.json
@@ -11,11 +11,13 @@
   "require-dev": {
     "phpunit/phpunit": "^5.1",
     "phpunit/php-code-coverage": "*",
-    "ext-xdebug": "*"
+    "ext-xdebug": "*",
+    "fabpot/php-cs-fixer": "^1.11.2"
   },
   "minimum-stability": "stable",
   "scripts": {
-    "test": "./vendor/bin/phpunit -c ./phpunit.xml"
+    "test": "./vendor/bin/phpunit -c ./phpunit.xml",
+    "fix": "./vendor/bin/php-cs-fixer fix"
   },
 
   "license": "MIT",

--- a/src/ArrayTokenStore.php
+++ b/src/ArrayTokenStore.php
@@ -7,31 +7,36 @@ use phpgt\csrf\exception\CSRFTokenSpentException;
 // NOTE that if this implementation is going to work across web requests, it
 // must be stored on the session - it has no other way of remembering the
 // tokens!
-class ArrayTokenStore extends TokenStore {
-	private $store = [ ];
+class ArrayTokenStore extends TokenStore
+{
+    private $store = [ ];
 
-	public function __construct(int $maxTokens = null) {
-		parent::__construct($maxTokens);
-	}
+    public function __construct(int $maxTokens = null)
+    {
+        parent::__construct($maxTokens);
+    }
 
-	public function saveToken(string $token) {
-		$this->store[ $token ] = null;
-		if(count($this->store) > self::$MAX_TOKENS) {
-			array_shift($this->store);
-		}
-	}
+    public function saveToken(string $token)
+    {
+        $this->store[ $token ] = null;
+        if (count($this->store) > self::$MAX_TOKENS) {
+            array_shift($this->store);
+        }
+    }
 
-	public function verifyToken(string $token) : bool {
-		if(!array_key_exists($token, $this->store)) {
-			throw new CSRFTokenInvalidException($token);
-		} elseif($this->store[ $token ] !== null) {
-			throw new CSRFTokenSpentException($token, $this->store[ $token ]);
-		} else {
-			return true;
-		}
-	}
+    public function verifyToken(string $token) : bool
+    {
+        if (!array_key_exists($token, $this->store)) {
+            throw new CSRFTokenInvalidException($token);
+        } elseif ($this->store[ $token ] !== null) {
+            throw new CSRFTokenSpentException($token, $this->store[ $token ]);
+        } else {
+            return true;
+        }
+    }
 
-	public function consumeToken(string $token) {
-		$this->store[ $token ] = time();
-	}
+    public function consumeToken(string $token)
+    {
+        $this->store[ $token ] = time();
+    }
 }#

--- a/src/ArrayTokenStore.php
+++ b/src/ArrayTokenStore.php
@@ -10,12 +10,15 @@ use phpgt\csrf\exception\CSRFTokenSpentException;
 class ArrayTokenStore extends TokenStore {
 	private $store = [ ];
 
-	public function __construct() {
-		parent::__construct();
+	public function __construct(int $maxTokens = null) {
+		parent::__construct($maxTokens);
 	}
 
 	public function saveToken(string $token) {
 		$this->store[ $token ] = null;
+		if(count($this->store) > self::$MAX_TOKENS) {
+			array_shift($this->store);
+		}
 	}
 
 	public function verifyToken(string $token) : bool {

--- a/src/HTMLDocumentProtector.php
+++ b/src/HTMLDocumentProtector.php
@@ -3,38 +3,42 @@ namespace phpgt\csrf;
 
 use phpgt\dom\HTMLDocument;
 
-class HTMLDocumentProtector {
-	public static $TOKEN_NAME = "csrf-token";
-	private       $doc;
-	private       $tokenStore;
+class HTMLDocumentProtector
+{
+    public static $TOKEN_NAME = "csrf-token";
+    private $doc;
+    private $tokenStore;
 
-	public function __construct($html, TokenStore $tokenStore) {
-		$this->tokenStore = $tokenStore;
+    public function __construct($html, TokenStore $tokenStore)
+    {
+        $this->tokenStore = $tokenStore;
 
-		if($html instanceof HTMLDocument) {
-			$this->doc = $html;
-		} else {
-			$this->doc = new HTMLDocument($html);
-		}
-	}
+        if ($html instanceof HTMLDocument) {
+            $this->doc = $html;
+        } else {
+            $this->doc = new HTMLDocument($html);
+        }
+    }
 
-	public function protectAndInject() {
-		$forms = $this->doc->forms;
-		if($forms->length > 0) {
-			$token = $this->tokenStore->generateNewToken();
-			$this->tokenStore->saveToken($token);
+    public function protectAndInject()
+    {
+        $forms = $this->doc->forms;
+        if ($forms->length > 0) {
+            $token = $this->tokenStore->generateNewToken();
+            $this->tokenStore->saveToken($token);
 
-			foreach($forms as $form) {
-				$csrfElement = $this->doc->createElement("input");
-				$csrfElement->setAttribute("name", static::$TOKEN_NAME);
-				$csrfElement->setAttribute("value", $token);
-				$csrfElement->setAttribute("type", "hidden");
-				$form->appendChild($csrfElement);
-			}
-		}
-	}
+            foreach ($forms as $form) {
+                $csrfElement = $this->doc->createElement("input");
+                $csrfElement->setAttribute("name", static::$TOKEN_NAME);
+                $csrfElement->setAttribute("value", $token);
+                $csrfElement->setAttribute("type", "hidden");
+                $form->appendChild($csrfElement);
+            }
+        }
+    }
 
-	public function getHTMLDocument() : \phpgt\dom\HTMLDocument {
-		return $this->doc;
-	}
+    public function getHTMLDocument() : \phpgt\dom\HTMLDocument
+    {
+        return $this->doc;
+    }
 }#

--- a/src/TokenStore.php
+++ b/src/TokenStore.php
@@ -5,43 +5,46 @@ use phpgt\csrf\exception\CSRFTokenMissingException;
 use RandomLib\Factory;
 use SecurityLib\Strength;
 
+abstract class TokenStore
+{
+    public static $MAX_TOKENS  = 1000;
+    private static $strength    = Strength::MEDIUM;
+    private static $tokenLength = 64;
+    private $tokenGenerator;
 
-abstract class TokenStore {
-	public static  $MAX_TOKENS  = 1000;
-	private static $strength    = Strength::MEDIUM;
-	private static $tokenLength = 64;
-	private        $tokenGenerator;
+    public function __construct(int $maxTokens = null)
+    {
+        if ($maxTokens !== null) {
+            self::$MAX_TOKENS = $maxTokens;
+        }
 
-	public function __construct(int $maxTokens = null) {
-		if($maxTokens !== null) {
-			self::$MAX_TOKENS = $maxTokens;
-		}
+        $factory = new Factory();
+        $this->tokenGenerator = $factory->getGenerator(
+            new Strength(self::$strength));
+    }
 
-		$factory = new Factory();
-		$this->tokenGenerator = $factory->getGenerator(
-			new Strength(self::$strength));
-	}
+    public function generateNewToken() : string
+    {
+        return $this->tokenGenerator->generateString(
+            self::$tokenLength);
+    }
 
-	public function generateNewToken() : string {
-		return $this->tokenGenerator->generateString(
-			self::$tokenLength);
-	}
+    public function processAndVerify()
+    {
+        // expect the token to be present on ALL post requests
+        if (!empty($_POST)) {
+            if (!isset($_POST[ HTMLDocumentProtector::$TOKEN_NAME ])) {
+                throw new CSRFTokenMissingException();
+            }
 
-	public function processAndVerify() {
-		// expect the token to be present on ALL post requests
-		if(!empty($_POST)) {
-			if(!isset($_POST[ HTMLDocumentProtector::$TOKEN_NAME ])) {
-				throw new CSRFTokenMissingException();
-			}
+            $this->verifyToken($_POST[ HTMLDocumentProtector::$TOKEN_NAME ]);
+            $this->consumeToken($_POST[ HTMLDocumentProtector::$TOKEN_NAME ]);
+        }
+    }
 
-			$this->verifyToken($_POST[ HTMLDocumentProtector::$TOKEN_NAME ]);
-			$this->consumeToken($_POST[ HTMLDocumentProtector::$TOKEN_NAME ]);
-		}
-	}
+    abstract public function saveToken(string $token);
 
-	public abstract function saveToken(string $token);
+    abstract public function consumeToken(string $token);
 
-	public abstract function consumeToken(string $token);
-
-	public abstract function verifyToken(string $token) : bool;
+    abstract public function verifyToken(string $token) : bool;
 }#

--- a/src/TokenStore.php
+++ b/src/TokenStore.php
@@ -7,11 +7,16 @@ use SecurityLib\Strength;
 
 
 abstract class TokenStore {
+	public static  $MAX_TOKENS  = 1000;
 	private static $strength    = Strength::MEDIUM;
 	private static $tokenLength = 64;
 	private        $tokenGenerator;
 
-	public function __construct() {
+	public function __construct(int $maxTokens = null) {
+		if($maxTokens !== null) {
+			self::$MAX_TOKENS = $maxTokens;
+		}
+
 		$factory = new Factory();
 		$this->tokenGenerator = $factory->getGenerator(
 			new Strength(self::$strength));

--- a/src/exception/CSRFException.php
+++ b/src/exception/CSRFException.php
@@ -1,10 +1,11 @@
 <?php
 namespace phpgt\csrf\exception;
 
-class CSRFException extends \Exception {
-	public function __construct(string $message, int $code = 403,
-	                            \Exception $previous = null
-	) {
-		parent::__construct($message, $code, $previous);
-	}
+class CSRFException extends \Exception
+{
+    public function __construct(string $message, int $code = 403,
+                                \Exception $previous = null
+    ) {
+        parent::__construct($message, $code, $previous);
+    }
 }#

--- a/src/exception/CSRFTokenInvalidException.php
+++ b/src/exception/CSRFTokenInvalidException.php
@@ -1,9 +1,11 @@
 <?php
 namespace phpgt\csrf\exception;
 
-class CSRFTokenInvalidException extends CSRFException {
+class CSRFTokenInvalidException extends CSRFException
+{
 
-	public function __construct(string $tokenReceived) {
-		parent::__construct("CSRF Token '{$tokenReceived}' does not exist");
-	}
+    public function __construct(string $tokenReceived)
+    {
+        parent::__construct("CSRF Token '{$tokenReceived}' does not exist");
+    }
 }#

--- a/src/exception/CSRFTokenMissingException.php
+++ b/src/exception/CSRFTokenMissingException.php
@@ -1,9 +1,11 @@
 <?php
 namespace phpgt\csrf\exception;
 
-class CSRFTokenMissingException extends CSRFException {
+class CSRFTokenMissingException extends CSRFException
+{
 
-	public function __construct() {
-		parent::__construct("CSRF Token not found on \$_POST");
-	}
+    public function __construct()
+    {
+        parent::__construct("CSRF Token not found on \$_POST");
+    }
 }#

--- a/src/exception/CSRFTokenSpentException.php
+++ b/src/exception/CSRFTokenSpentException.php
@@ -1,12 +1,13 @@
 <?php
 namespace phpgt\csrf\exception;
 
-class CSRFTokenSpentException extends CSRFException {
+class CSRFTokenSpentException extends CSRFException
+{
 
-	public function __construct(string $tokenReceived, string $previousUseTime
-	) {
-		parent::__construct(
-			"CSRF Token '{$tokenReceived}' previously used at " . date(
-				"c", $previousUseTime));
-	}
+    public function __construct(string $tokenReceived, string $previousUseTime
+    ) {
+        parent::__construct(
+            "CSRF Token '{$tokenReceived}' previously used at " . date(
+                "c", $previousUseTime));
+    }
 }#

--- a/test/ArrayTokenStoreTest.test.php
+++ b/test/ArrayTokenStoreTest.test.php
@@ -1,86 +1,91 @@
 <?php
 namespace phpgt\csrf;
 
-class ArrayTokenStoreTest extends \PHPUnit_Framework_TestCase {
+class ArrayTokenStoreTest extends \PHPUnit_Framework_TestCase
+{
+    public function testATokenExists()
+    {
+        $sut = new ArrayTokenStore();
+        // generate a token
+        $token = $sut->generateNewToken();
+        $sut->saveToken($token);
+        // check it exists
+        $this->assertTrue($sut->verifyToken($token));
+    }
 
-	public function testATokenExists() {
-		$sut = new ArrayTokenStore();
-		// generate a token
-		$token = $sut->generateNewToken();
-		$sut->saveToken($token);
-		// check it exists
-		$this->assertTrue($sut->verifyToken($token));
-	}
+    // token doesn't exist
+    public function testATokenDoesntExist()
+    {
+        $sut = new ArrayTokenStore();
 
-	// token doesn't exist
-	public function testATokenDoesntExist() {
-		$sut = new ArrayTokenStore();
+        // see if a non-existent token passes
+        $this->expectException(
+            "\\phpgt\\csrf\\exception\\CSRFTokenInvalidException");
+        $sut->verifyToken("mickey mouse");
+    }
 
-		// see if a non-existent token passes
-		$this->expectException(
-			"\\phpgt\\csrf\\exception\\CSRFTokenInvalidException");
-		$sut->verifyToken("mickey mouse");
-	}
+    // token exists and has been consumed
+    public function testConsumeAToken()
+    {
+        $sut = new ArrayTokenStore();
 
-	// token exists and has been consumed
-	public function testConsumeAToken() {
-		$sut = new ArrayTokenStore();
+        // generate a token
+        $token = $sut->generateNewToken();
+        $sut->saveToken($token);
 
-		// generate a token
-		$token = $sut->generateNewToken();
-		$sut->saveToken($token);
+        // now consume it
+        $sut->consumeToken($token);
 
-		// now consume it
-		$sut->consumeToken($token);
+        // and make sure it no longer passes verification
+        $this->expectException(
+            "\\phpgt\\csrf\\exception\\CSRFTokenSpentException");
+        $sut->verifyToken($token);
+    }
 
-		// and make sure it no longer passes verification
-		$this->expectException(
-			"\\phpgt\\csrf\\exception\\CSRFTokenSpentException");
-		$sut->verifyToken($token);
-	}
+    // ensure the limit to the number of tokens works
+    public function testTokenLimit()
+    {
+        $sut = new ArrayTokenStore();
+        $firstToken = $sut->generateNewToken();
+        $sut->saveToken($firstToken);
 
-	// ensure the limit to the number of tokens works
-	public function testTokenLimit() {
-		$sut = new ArrayTokenStore();
-		$firstToken = $sut->generateNewToken();
-		$sut->saveToken($firstToken);
+        $tokens = 1;
+        $lastToken = null;
+        while ($tokens++ <= $sut::$MAX_TOKENS) {
+            $lastToken = $sut->generateNewToken();
+            $sut->saveToken($lastToken);
+        }
 
-		$tokens = 1;
-		$lastToken = null;
-		while($tokens++ <= $sut::$MAX_TOKENS) {
-			$lastToken = $sut->generateNewToken();
-			$sut->saveToken($lastToken);
-		}
+        $sut->verifyToken($lastToken);
+        // now we've hit the max, the original token should no longer be valid
+        $this->expectException(
+            "\\phpgt\\csrf\\exception\\CSRFTokenInvalidException");
+        $sut->verifyToken($firstToken);
+    }
 
-		$sut->verifyToken($lastToken);
-		// now we've hit the max, the original token should no longer be valid
-		$this->expectException(
-			"\\phpgt\\csrf\\exception\\CSRFTokenInvalidException");
-		$sut->verifyToken($firstToken);
-	}
+    public function testChangeTokenLimit()
+    {
+        $tokenLimit = 5;
+        $sut = new ArrayTokenStore($tokenLimit);
 
-	public function testChangeTokenLimit() {
-		$tokenLimit = 5;
-		$sut = new ArrayTokenStore($tokenLimit);
-
-		// check that the new limit has stuck
-		$this->assertEquals($tokenLimit, $sut::$MAX_TOKENS);
+        // check that the new limit has stuck
+        $this->assertEquals($tokenLimit, $sut::$MAX_TOKENS);
 
 
-		$firstToken = $sut->generateNewToken();
-		$sut->saveToken($firstToken);
+        $firstToken = $sut->generateNewToken();
+        $sut->saveToken($firstToken);
 
-		$tokens = 1;
-		$lastToken = null;
-		while($tokens++ <= $tokenLimit) {
-			$lastToken = $sut->generateNewToken();
-			$sut->saveToken($lastToken);
-		}
+        $tokens = 1;
+        $lastToken = null;
+        while ($tokens++ <= $tokenLimit) {
+            $lastToken = $sut->generateNewToken();
+            $sut->saveToken($lastToken);
+        }
 
-		$sut->verifyToken($lastToken);
-		// now we've hit the max, the original token should no longer be valid
-		$this->expectException(
-			"\\phpgt\\csrf\\exception\\CSRFTokenInvalidException");
-		$sut->verifyToken($firstToken);
-	}
+        $sut->verifyToken($lastToken);
+        // now we've hit the max, the original token should no longer be valid
+        $this->expectException(
+            "\\phpgt\\csrf\\exception\\CSRFTokenInvalidException");
+        $sut->verifyToken($firstToken);
+    }
 }

--- a/test/ArrayTokenStoreTest.test.php
+++ b/test/ArrayTokenStoreTest.test.php
@@ -38,4 +38,49 @@ class ArrayTokenStoreTest extends \PHPUnit_Framework_TestCase {
 			"\\phpgt\\csrf\\exception\\CSRFTokenSpentException");
 		$sut->verifyToken($token);
 	}
+
+	// ensure the limit to the number of tokens works
+	public function testTokenLimit() {
+		$sut = new ArrayTokenStore();
+		$firstToken = $sut->generateNewToken();
+		$sut->saveToken($firstToken);
+
+		$tokens = 1;
+		$lastToken = null;
+		while($tokens++ <= $sut::$MAX_TOKENS) {
+			$lastToken = $sut->generateNewToken();
+			$sut->saveToken($lastToken);
+		}
+
+		$sut->verifyToken($lastToken);
+		// now we've hit the max, the original token should no longer be valid
+		$this->expectException(
+			"\\phpgt\\csrf\\exception\\CSRFTokenInvalidException");
+		$sut->verifyToken($firstToken);
+	}
+
+	public function testChangeTokenLimit() {
+		$tokenLimit = 5;
+		$sut = new ArrayTokenStore($tokenLimit);
+
+		// check that the new limit has stuck
+		$this->assertEquals($tokenLimit, $sut::$MAX_TOKENS);
+
+
+		$firstToken = $sut->generateNewToken();
+		$sut->saveToken($firstToken);
+
+		$tokens = 1;
+		$lastToken = null;
+		while($tokens++ <= $tokenLimit) {
+			$lastToken = $sut->generateNewToken();
+			$sut->saveToken($lastToken);
+		}
+
+		$sut->verifyToken($lastToken);
+		// now we've hit the max, the original token should no longer be valid
+		$this->expectException(
+			"\\phpgt\\csrf\\exception\\CSRFTokenInvalidException");
+		$sut->verifyToken($firstToken);
+	}
 }

--- a/test/HTMLDocumentProtectorTest.test.php
+++ b/test/HTMLDocumentProtectorTest.test.php
@@ -1,9 +1,10 @@
 <?php
 namespace phpgt\csrf;
 
-class HTMLDocumentProtectorTest extends \PHPUnit_Framework_TestCase {
-	const NO_FORMS
-		= <<<HTML
+class HTMLDocumentProtectorTest extends \PHPUnit_Framework_TestCase
+{
+    const NO_FORMS
+        = <<<HTML
 <!doctype html>
 <html>
 <head>
@@ -17,8 +18,8 @@ class HTMLDocumentProtectorTest extends \PHPUnit_Framework_TestCase {
 </html>
 HTML;
 
-	const ONE_FORM
-		= <<<HTML
+    const ONE_FORM
+        = <<<HTML
 <!doctype html>
 <html>
 <head>
@@ -36,8 +37,8 @@ HTML;
 </html>
 HTML;
 
-	const THREE_FORMS
-		= <<<HTML
+    const THREE_FORMS
+        = <<<HTML
 <!doctype html>
 <html>
 <head>
@@ -62,83 +63,88 @@ HTML;
 </html>
 HTML;
 
-	public function testConstructFromString() {
-		$sut = new HTMLDocumentProtector(self::NO_FORMS, new ArrayTokenStore());
-		$doc = $sut->getHTMLDocument();
-		$this->assertInstanceOf("\\phpgt\\dom\\HTMLDocument", $doc);
-		$this->assertEquals(
-			"Test HTML", $doc->querySelector("title")->textContent);
-	}
+    public function testConstructFromString()
+    {
+        $sut = new HTMLDocumentProtector(self::NO_FORMS, new ArrayTokenStore());
+        $doc = $sut->getHTMLDocument();
+        $this->assertInstanceOf("\\phpgt\\dom\\HTMLDocument", $doc);
+        $this->assertEquals(
+            "Test HTML", $doc->querySelector("title")->textContent);
+    }
 
-	public function testConstructFromDomDocument() {
-		$domDoc = new \phpgt\dom\HTMLDocument(self::ONE_FORM);
-		$sut = new HTMLDocumentProtector($domDoc, new ArrayTokenStore());
-		$doc = $sut->getHTMLDocument();
-		$this->assertSame($domDoc, $doc);
-		$this->assertEquals(
-			"Test HTML", $doc->querySelector("title")->textContent);
-	}
+    public function testConstructFromDomDocument()
+    {
+        $domDoc = new \phpgt\dom\HTMLDocument(self::ONE_FORM);
+        $sut = new HTMLDocumentProtector($domDoc, new ArrayTokenStore());
+        $doc = $sut->getHTMLDocument();
+        $this->assertSame($domDoc, $doc);
+        $this->assertEquals(
+            "Test HTML", $doc->querySelector("title")->textContent);
+    }
 
-	public function testZeroForms() {
-		$sut = new HTMLDocumentProtector(self::NO_FORMS, new ArrayTokenStore());
-		$sut->protectAndInject();
+    public function testZeroForms()
+    {
+        $sut = new HTMLDocumentProtector(self::NO_FORMS, new ArrayTokenStore());
+        $sut->protectAndInject();
 
-		// check that the token hasn't been injected anywhere
-		$this->assertFalse(
-			strpos(
-				$sut->getHTMLDocument()->saveHTML(),
-				HTMLDocumentProtector::$TOKEN_NAME));
-		// and that a form hasn't been created or something similar
-		$this->assertNull($sut->getHTMLDocument()->querySelector("form"));
-	}
+        // check that the token hasn't been injected anywhere
+        $this->assertFalse(
+            strpos(
+                $sut->getHTMLDocument()->saveHTML(),
+                HTMLDocumentProtector::$TOKEN_NAME));
+        // and that a form hasn't been created or something similar
+        $this->assertNull($sut->getHTMLDocument()->querySelector("form"));
+    }
 
-	public function testSingleForm() {
-		$sut = new HTMLDocumentProtector(self::ONE_FORM, new ArrayTokenStore());
-		$sut->protectAndInject();
+    public function testSingleForm()
+    {
+        $sut = new HTMLDocumentProtector(self::ONE_FORM, new ArrayTokenStore());
+        $sut->protectAndInject();
 
-		// check that the token has been injected
-		$doc = $sut->getHTMLDocument();
-		$this->assertTrue(
-			strpos($doc->saveHTML(), HTMLDocumentProtector::$TOKEN_NAME) >= 0);
-		$this->assertNotNull(
-			$doc->querySelector(
-				"input[name='" . HTMLDocumentProtector::$TOKEN_NAME . "']"));
-		$this->assertNotEmpty(
-			$doc->querySelector(
-				"input[name='" . HTMLDocumentProtector::$TOKEN_NAME . "']")
-			    ->getAttribute("value"));
-	}
+        // check that the token has been injected
+        $doc = $sut->getHTMLDocument();
+        $this->assertTrue(
+            strpos($doc->saveHTML(), HTMLDocumentProtector::$TOKEN_NAME) >= 0);
+        $this->assertNotNull(
+            $doc->querySelector(
+                "input[name='" . HTMLDocumentProtector::$TOKEN_NAME . "']"));
+        $this->assertNotEmpty(
+            $doc->querySelector(
+                "input[name='" . HTMLDocumentProtector::$TOKEN_NAME . "']")
+                ->getAttribute("value"));
+    }
 
-	public function testMultipleForms() {
-		$sut = new HTMLDocumentProtector(self::THREE_FORMS, new ArrayTokenStore());
-		$sut->protectAndInject();
+    public function testMultipleForms()
+    {
+        $sut = new HTMLDocumentProtector(self::THREE_FORMS, new ArrayTokenStore());
+        $sut->protectAndInject();
 
-		// check that the token has been injected in all forms
-		$doc = $sut->getHTMLDocument();
-		$this->assertEquals(
-			3, $doc->querySelectorAll(
-			"input[name='" . HTMLDocumentProtector::$TOKEN_NAME . "']")->length);
-	}
+        // check that the token has been injected in all forms
+        $doc = $sut->getHTMLDocument();
+        $this->assertEquals(
+            3, $doc->querySelectorAll(
+            "input[name='" . HTMLDocumentProtector::$TOKEN_NAME . "']")->length);
+    }
 
-	// we don't need separate tokens for each form - that would be both wasteful,
-	// and would increase the number of valid tokens that could be guessed
-	// (particularly as at most one would ever be consumed & so burnt, leaving
-	// lots of valid tokens lying around).  So check that one token is shared
-	// across all of the forms
-	public function testSingleCodeSharedAcrossForms() {
+    // we don't need separate tokens for each form - that would be both wasteful,
+    // and would increase the number of valid tokens that could be guessed
+    // (particularly as at most one would ever be consumed & so burnt, leaving
+    // lots of valid tokens lying around).  So check that one token is shared
+    // across all of the forms
+    public function testSingleCodeSharedAcrossForms()
+    {
+        $sut = new HTMLDocumentProtector(self::THREE_FORMS, new ArrayTokenStore());
+        $sut->protectAndInject();
 
-		$sut = new HTMLDocumentProtector(self::THREE_FORMS, new ArrayTokenStore());
-		$sut->protectAndInject();
-
-		$doc = $sut->getHTMLDocument();
-		$token = null;
-		foreach($doc->querySelectorAll(
-			"input[name='" . HTMLDocumentProtector::$TOKEN_NAME . "']") as $input) {
-			if($token === null) {
-				$token = $input->getAttribute("value");
-			} else {
-				$this->assertEquals($token, $input->getAttribute("value"));
-			}
-		}
-	}
+        $doc = $sut->getHTMLDocument();
+        $token = null;
+        foreach ($doc->querySelectorAll(
+            "input[name='" . HTMLDocumentProtector::$TOKEN_NAME . "']") as $input) {
+            if ($token === null) {
+                $token = $input->getAttribute("value");
+            } else {
+                $this->assertEquals($token, $input->getAttribute("value"));
+            }
+        }
+    }
 }#

--- a/test/TokenStoreTest.test.php
+++ b/test/TokenStoreTest.test.php
@@ -2,9 +2,10 @@
 namespace phpgt\csrf;
 
 // NOTE - only test the non-abstract functionality
-class TokenStoreTest extends \PHPUnit_Framework_TestCase {
-	const ONE_FORM
-		= <<<HTML
+class TokenStoreTest extends \PHPUnit_Framework_TestCase
+{
+    const ONE_FORM
+        = <<<HTML
 <!doctype html>
 <html>
 <head>
@@ -21,72 +22,78 @@ class TokenStoreTest extends \PHPUnit_Framework_TestCase {
 </body>
 HTML;
 
-	// no post request received
-	public function testNoPOST() {
-		$sut = new ArrayTokenStore();
-		$sut->processAndVerify();
-	}
+    // no post request received
+    public function testNoPOST()
+    {
+        $sut = new ArrayTokenStore();
+        $sut->processAndVerify();
+    }
 
-	// POST request received but without a token
-	public function testNoToken() {
-		$_POST["doink"] = "binky";
-		$sut = new ArrayTokenStore();
-		$this->expectException(
-			"\\phpgt\\csrf\\exception\\CSRFTokenMissingException");
-		$sut->processAndVerify();
-	}
+    // POST request received but without a token
+    public function testNoToken()
+    {
+        $_POST["doink"] = "binky";
+        $sut = new ArrayTokenStore();
+        $this->expectException(
+            "\\phpgt\\csrf\\exception\\CSRFTokenMissingException");
+        $sut->processAndVerify();
+    }
 
-	// POST request received with token but invalid
-	public function testInvalidToken() {
-		$_POST["doink"] = "binky";
-		$_POST[ HTMLDocumentProtector::$TOKEN_NAME ] = "12321";
-		$sut = new ArrayTokenStore();
-		$this->expectException(
-			"\\phpgt\\csrf\\exception\\CSRFTokenInvalidException");
-		$sut->processAndVerify();
-	}
+    // POST request received with token but invalid
+    public function testInvalidToken()
+    {
+        $_POST["doink"] = "binky";
+        $_POST[ HTMLDocumentProtector::$TOKEN_NAME ] = "12321";
+        $sut = new ArrayTokenStore();
+        $this->expectException(
+            "\\phpgt\\csrf\\exception\\CSRFTokenInvalidException");
+        $sut->processAndVerify();
+    }
 
-	// POST request received with token but invalid
-	public function testSpentToken() {
-		$tokenStore = new ArrayTokenStore();
-		$token = $tokenStore->generateNewToken();
-		$tokenStore->saveToken($token);
-		$tokenStore->consumeToken($token);
+    // POST request received with token but invalid
+    public function testSpentToken()
+    {
+        $tokenStore = new ArrayTokenStore();
+        $token = $tokenStore->generateNewToken();
+        $tokenStore->saveToken($token);
+        $tokenStore->consumeToken($token);
 
-		$_POST["doink"] = "binky";
-		// add the token as if it were from a previous page
-		$_POST[ HTMLDocumentProtector::$TOKEN_NAME ] = $token;
+        $_POST["doink"] = "binky";
+        // add the token as if it were from a previous page
+        $_POST[ HTMLDocumentProtector::$TOKEN_NAME ] = $token;
 
-		$this->expectException(
-			"\\phpgt\\csrf\\exception\\CSRFTokenSpentException");
-		$tokenStore->processAndVerify();
-	}
+        $this->expectException(
+            "\\phpgt\\csrf\\exception\\CSRFTokenSpentException");
+        $tokenStore->processAndVerify();
+    }
 
-	// POST request received with token and valid
-	public function testValidToken() {
-		$tokenStore = new ArrayTokenStore();
-		$token = $tokenStore->generateNewToken();
-		$tokenStore->saveToken($token);
+    // POST request received with token and valid
+    public function testValidToken()
+    {
+        $tokenStore = new ArrayTokenStore();
+        $token = $tokenStore->generateNewToken();
+        $tokenStore->saveToken($token);
 
-		$_POST["doink"] = "binky";
-		// add the token as if it were from a previous page
-		$_POST[ HTMLDocumentProtector::$TOKEN_NAME ] = $token;
+        $_POST["doink"] = "binky";
+        // add the token as if it were from a previous page
+        $_POST[ HTMLDocumentProtector::$TOKEN_NAME ] = $token;
 
-		$tokenStore->processAndVerify();
-	}
+        $tokenStore->processAndVerify();
+    }
 
-	// check that repeated calls to the token generator result in unique tokens
-	public function testCodesAreUnique() {
-		$sut = new ArrayTokenStore();
-		$previousTokens = [ ];
+    // check that repeated calls to the token generator result in unique tokens
+    public function testCodesAreUnique()
+    {
+        $sut = new ArrayTokenStore();
+        $previousTokens = [ ];
 
-		$iterations = 5;
-		for($i = 0; $i < $iterations; $i++) {
-			$token = $sut->generateNewToken();
-			$this->assertArrayNotHasKey($token, $previousTokens);
-			$previousTokens[ $token ] = null;
-		}
+        $iterations = 5;
+        for ($i = 0; $i < $iterations; $i++) {
+            $token = $sut->generateNewToken();
+            $this->assertArrayNotHasKey($token, $previousTokens);
+            $previousTokens[ $token ] = null;
+        }
 
-		$this->assertEquals($iterations, count($previousTokens));
-	}
+        $this->assertEquals($iterations, count($previousTokens));
+    }
 }


### PR DESCRIPTION
Also added php_cs_fixer to make auto-enforcement easy.

This move to PSR2 should resolve the handful of scrutinizer flags about ordering of keywords etc.