### PR TITLE
Handle malformed CSRF token types in verify()

### DIFF
--- a/src/Exception/CsrfTokenMalformedException.php
+++ b/src/Exception/CsrfTokenMalformedException.php
@@ -1,0 +1,8 @@
+<?php
+namespace GT\Csrf\Exception;
+
+class CsrfTokenMalformedException extends CsrfException {
+	public function __construct() {
+		parent::__construct("CSRF Token is malformed");
+	}
+}

--- a/src/TokenStore.php
+++ b/src/TokenStore.php
@@ -75,7 +75,7 @@ abstract class TokenStore {
 		}
 
 		if(!empty($postData)) {
-            $token = $postData[HTMLDocumentProtector::TOKEN_NAME] ?? null;
+			$token = $postData[HTMLDocumentProtector::TOKEN_NAME] ?? null;
 
 			if(!isset($token)) {
 				throw new CsrfTokenMissingException();

--- a/src/TokenStore.php
+++ b/src/TokenStore.php
@@ -2,6 +2,7 @@
 namespace GT\Csrf;
 
 use GT\Csrf\Exception\CsrfTokenInvalidException;
+use GT\Csrf\Exception\CsrfTokenMalformedException;
 use GT\Csrf\Exception\CsrfTokenMissingException;
 use GT\Csrf\Exception\CsrfTokenSpentException;
 use GT\Ulid\Ulid;
@@ -55,11 +56,13 @@ abstract class TokenStore {
 	 * If a $_POST global exists, check that it contains a token and that the token is valid.
 	 * The name the token is stored-under is contained in HTMLDocumentProtector::TOKEN_NAME.
 	 *
-	 * @param array<string, int>|object $postData
+	 * @param array<string, mixed>|object $postData
 	 * @throws CsrfTokenMissingException There's a $_POST request present but no
 	 * token present
 	 * @throws CsrfTokenInvalidException There's a token included on the $_POST,
-	 * but its value is invalid.
+	 * but its value is not known to the store.
+	 * @throws CsrfTokenMalformedException There's a token included on the
+	 * $_POST, but it is not a string.
 	 * @throws CsrfTokenSpentException  There's a token included on the
 	 * $_POST but it has already been consumed by a previous request.
 	 * @see TokenStore::verifyToken().
@@ -72,12 +75,18 @@ abstract class TokenStore {
 		}
 
 		if(!empty($postData)) {
-			if(!isset($postData[HTMLDocumentProtector::TOKEN_NAME])) {
+            $token = $postData[HTMLDocumentProtector::TOKEN_NAME] ?? null;
+
+			if(!isset($token)) {
 				throw new CsrfTokenMissingException();
 			}
 
-			$this->verifyToken($postData[HTMLDocumentProtector::TOKEN_NAME]);
-			$this->consumeToken($postData[HTMLDocumentProtector::TOKEN_NAME]);
+			if(!is_string($token)) {
+				throw new CsrfTokenMalformedException();
+			}
+
+			$this->verifyToken($token);
+			$this->consumeToken($token);
 		}
 	}
 

--- a/test/phpunit/TokenStoreTest.php
+++ b/test/phpunit/TokenStoreTest.php
@@ -5,6 +5,7 @@ use Exception;
 use GT\Csrf\ArrayTokenStore;
 use GT\Csrf\Exception\CsrfException;
 use GT\Csrf\Exception\CsrfTokenInvalidException;
+use GT\Csrf\Exception\CsrfTokenMalformedException;
 use GT\Csrf\Exception\CsrfTokenMissingException;
 use GT\Csrf\Exception\CsrfTokenSpentException;
 use GT\Csrf\HTMLDocumentProtector;
@@ -60,6 +61,16 @@ class TokenStoreTest extends TestCase {
 		$post[HTMLDocumentProtector::TOKEN_NAME] = "12321";
 		$sut = new ArrayTokenStore();
 		$this->expectException(CSRFTokenInvalidException::class);
+		$sut->verify($post);
+	}
+
+	/** POST request received with token present, but not as a string */
+	public function testVerify_invalidTokenType():void {
+		$post = [];
+		$post["doink"] = "binky";
+		$post[HTMLDocumentProtector::TOKEN_NAME] = 123;
+		$sut = new ArrayTokenStore();
+		$this->expectException(CsrfTokenMalformedException::class);
 		$sut->verify($post);
 	}
 


### PR DESCRIPTION
Closes #215 

• Fixed the input type handling in TokenStore::verify
• Added a new CsrfTokenMalformedException
• Updated the PHPDoc for verify
• Added a test for an invalid token type